### PR TITLE
Chore/5.5.1 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - "*"
+  pull_request:
+    branches:
+    - main
+
+
+jobs:
+  tag:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install dependencies
+      uses: php-actions/composer@v2
+      with:
+        dev: no
+    - name: Build package
+      run: cp -ar vendor src/
+    - name: WordPress Plugin Deploy
+      uses: 10up/action-wordpress-plugin-deploy@master
+      env:
+        GITHUB_WORKSPACE: ./src
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: enable-svg-uploads
+        VERSION: 2.0.21

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,21 @@ jobs:
     - uses: actions/checkout@master
     - name: Install dependencies
       uses: php-actions/composer@v2
+      id: composer
       with:
         dev: no
     - name: Build package
-      run: cp -ar vendor src/
+      run: cp -ar ./vendor src/
+    - name: List files
+      run: ls -lhaR src
+    - name: Commit Vendor folder (but don't push)
+      run: |
+        git config --global user.email "bot+github@codesign2.co.uk" &&
+        git config --global user.name "CD2 bot on GitHub" &&
+        sed -e '/vendor/ s/^#*/#/' -i .gitignore &&
+        git add .gitignore &&
+        git add -f vendor . &&
+        git commit -m "Vendored dependencies"
     - name: WordPress Plugin Deploy
       uses: Lewiscowles1986/action-wordpress-plugin-deploy@feat/add-custom-workspace
       env:
@@ -28,4 +39,4 @@ jobs:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: enable-svg-uploads
-        VERSION: 2.0.21
+        VERSION: 2.0.29

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,6 @@ on:
   push:
     tags:
     - "*"
-  pull_request:
-    branches:
-    - main
-
 
 jobs:
   tag:
@@ -22,8 +18,6 @@ jobs:
         dev: no
     - name: Build package
       run: cp -ar ./vendor src/
-    - name: List files
-      run: ls -lhaR src
     - name: Commit Vendor folder (but don't push)
       run: |
         git config --global user.email "bot+github@codesign2.co.uk" &&
@@ -39,4 +33,3 @@ jobs:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: enable-svg-uploads
-        VERSION: 2.0.29

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
     - name: Build package
       run: cp -ar vendor src/
     - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@master
+      uses: Lewiscowles1986/action-wordpress-plugin-deploy@feat/add-custom-workspace
       env:
-        GITHUB_WORKSPACE: ./src
+        WORKSPACE_DIR: src
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: enable-svg-uploads

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "lewiscowles1986/lc-enable-svg",
   "type": "wordpress-plugin",
   "description": "A small WordPress plugin to enable SVG uploads in Media Library and other file upload fields.",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "license": "GPL-3.0",
   "homepage": "https://github.com/Lewiscowles1986/WordPressSVGPlugin",
   "authors": [

--- a/src/index.php
+++ b/src/index.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Enable SVG Uploads
  * Plugin URI:        https://github.com/Lewiscowles1986/WordPressSVGPlugin
  * Description:       Enable SVG uploads in Media Library and other file upload fields.
- * Version:           2.0.2
+ * Version:           2.0.3
  * Author:            Lewis Cowles
  * Author URI:        https://www.lewiscowles.co.uk/
  * License:           GPL-3.0

--- a/src/index.php
+++ b/src/index.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Enable SVG Uploads
  * Plugin URI:        https://github.com/Lewiscowles1986/WordPressSVGPlugin
  * Description:       Enable SVG uploads in Media Library and other file upload fields.
- * Version:           2.0.3
+ * Version:           2.1.0
  * Author:            Lewis Cowles
  * Author URI:        https://www.lewiscowles.co.uk/
  * License:           GPL-3.0

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Tags: svg,upload,media library,mime
 Requires at least: 4.0
 Tested up to: 5.4.2
 Requires PHP: 7.0
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: GPL-3.0
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -27,6 +27,13 @@ Download and extract the zip file or clone this repo to your WordPress plugins d
 After an upgrade to 2.x it may be necessary to download and re-upload your SVG media files so that the grid works. This is because we now use simple XML to retrieve the width & height of the SVG.
 
 == Changelog ==
+= 2.0.3 =
+* GitHub -> WordPress Plugin Directory
+* GitHub CI
+* PHPUnit update
+* Contribution issue format
+* Confirmed working for 5.5.1
+
 = 2.0.2 =
 * Modified CSS added (we now get CSS size from correctly marked up SVG's anyway)
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Tags: svg,upload,media library,mime
 Requires at least: 4.0
 Tested up to: 5.4.2
 Requires PHP: 7.0
-Stable tag: 2.0.3
+Stable tag: 2.1.0
 License: GPL-3.0
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -27,7 +27,7 @@ Download and extract the zip file or clone this repo to your WordPress plugins d
 After an upgrade to 2.x it may be necessary to download and re-upload your SVG media files so that the grid works. This is because we now use simple XML to retrieve the width & height of the SVG.
 
 == Changelog ==
-= 2.0.3 =
+= 2.1.0 =
 * GitHub -> WordPress Plugin Directory
 * GitHub CI
 * PHPUnit update


### PR DESCRIPTION
WordPress 5.5.1 support.

I would also like to reduce the burden of administering / coordinating various functions so:

* GitHub action
  * Release
* 5.5.1 file edits (no behaviour is changing)